### PR TITLE
Add clean

### DIFF
--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -869,9 +869,6 @@ FarmerInterface.prototype.performClean = function (streamOptions, endShardStream
       return callback(err);
     }
 
-    console.log('Last Shard: ', lastShard)
-    console.log('End Stream Shard: ', endShardStream)
-
     if (coreShards.length > 0) {
       this.getShardsFromBridge(coreShards, (err, bridgeShards) => {
         if (err) {

--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -838,20 +838,43 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
 /************************************************
  * Cleaner
  ************************************************/
- FarmerInterface.prototype.initCleaner = function(callback) {
-  let self = this;
+ FarmerInterface.prototype.initCleaner = function(greaterThan, endShardStream, callback) {
+  const self = this;
 
-  self.storageManager.readAllContracts((err, arr) => {
+  /** We make 500 shards batch **/
+  const streamOptions = {
+    limit: 2,
+    gt: greaterThan
+  } 
+
+  if(!endShardStream)
+  {
+    endShardStream = self.storageManager.getLastShard();
+  }
+
+  self.storageManager.readShards(streamOptions, (err, arr, lastShard) => {
     if (err) {
       return callback(err);
     }
+    
     this.getShardsFromBridge(arr, (err, bridgeShards) => {
       if(err) {
         callback(err);
       }
-      console.log('Core Shards', arr);
-      console.log('Bridge Shards', bridgeShards);
-      self.storageManager.cleaner(bridgeShards, callback);
+      self._logger.info('Core Shards', arr);
+      self._logger.info('Bridge Shards', bridgeShards);
+      self.storageManager.cleaner(bridgeShards, streamOptions, (err) => {
+        if(err) {
+          callback(err)
+        }
+        
+        /**
+         * We repeat the process until with finish with all the shards
+         */
+        if(lastShard !== endShardStream) {
+          this.initCleaner(lastShard, endShardStream, callback);
+        } 
+      });
     });
   });
 }
@@ -859,8 +882,6 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
 /**
  * 
  * Send shards to bridge and it responds with the ones that are on the DDBB
- * 
- * TODO: To split the Shards array to X number to not call the bridge with to many hash
  * 
  * @param {Array} shards 
  * @param {Function} callback 
@@ -882,15 +903,7 @@ FarmerInterface.prototype._getShardsFromBridge = function(bridge, shards, callba
   let body = {shards};
   let path = '/contacts/shards';
   
-  this.bridgeRequest(bridge.url, 'POST', path, headers, body, (err, shardsRetrieved) => {
-    if (err && err.statusCode >= 400) {
-      return callback(err);
-    } 
-
-    if (shardsRetrieved) {
-      callback(null, shardsRetrieved);
-    }
-  });
+  this.bridgeRequest(bridge.url, 'POST', path, headers, body, callback);
 }
 
 module.exports = FarmerInterface;

--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -841,7 +841,7 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
  FarmerInterface.prototype.initCleaner = function(callback) {
   let self = this;
 
-  this._getShards((err, arr) => {
+  self.storageManager.readAllContracts((err, arr) => {
     if (err) {
       return callback(err);
     }
@@ -854,11 +854,6 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
       self.storageManager.cleaner(bridgeShards, callback);
     });
   });
-}
-
-FarmerInterface.prototype._getShards = function(callback) {
-  const self = this;
-  self.storageManager.readAllContracts(callback);
 }
 
 /**

--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -835,4 +835,67 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
   });
 }
 
+/************************************************
+ * Cleaner
+ ************************************************/
+ FarmerInterface.prototype.initCleaner = function(callback) {
+  let self = this;
+
+  this._getShards((err, arr) => {
+    if (err) {
+      return callback(err);
+    }
+    this.getShardsFromBridge(arr, (err, bridgeShards) => {
+      if(err) {
+        callback(err);
+      }
+      console.log('Core Shards', arr);
+      console.log('Bridge Shards', bridgeShards);
+      self.storageManager.cleaner(bridgeShards, callback);
+    });
+  });
+}
+
+FarmerInterface.prototype._getShards = function(callback) {
+  const self = this;
+  self.storageManager.readAllContracts(callback);
+}
+
+/**
+ * 
+ * Send shards to bridge and it responds with the ones that are on the DDBB
+ * 
+ * TODO: To split the Shards array to X number to not call the bridge with to many hash
+ * 
+ * @param {Array} shards 
+ * @param {Function} callback 
+ */
+FarmerInterface.prototype.getShardsFromBridge = function(shards, callback) {
+  const bridgeIter = this.bridges.values()
+  this._getShardsFromBridge(bridgeIter.next().value, shards, (err, shardsRetrieved) => {
+    if(err) {
+      callback(err);
+    }
+    else {
+      callback(null, shardsRetrieved);
+    }
+  })
+}
+
+FarmerInterface.prototype._getShardsFromBridge = function(bridge, shards, callback) {
+  let headers = {};
+  let body = {shards};
+  let path = '/contacts/shards';
+  
+  this.bridgeRequest(bridge.url, 'POST', path, headers, body, (err, shardsRetrieved) => {
+    if (err && err.statusCode >= 400) {
+      return callback(err);
+    } 
+
+    if (shardsRetrieved) {
+      callback(null, shardsRetrieved);
+    }
+  });
+}
+
 module.exports = FarmerInterface;

--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -18,7 +18,7 @@ const merge = require('merge');
 const constants = require('../constants');
 const diskusage = require('diskusage');
 const utils = require('../utils');
-const {execFile} = require('child_process');
+const { execFile } = require('child_process');
 
 /**
  * Creates and a new farmer interface
@@ -103,36 +103,36 @@ FarmerInterface.CONNECT_BRIDGE_INTERVAL = 10000;
 FarmerInterface.CHECK_SPACE_USED_INTERVAL = 86400000;
 FarmerInterface.FREE_SPACE_PADDING = constants.FREE_SPACE_PADDING;
 
-FarmerInterface.prototype._deprecatedConfigV1 = function(options) {
+FarmerInterface.prototype._deprecatedConfigV1 = function (options) {
   if (options.renterWhitelist) {
     this._logger.warn('config renterWhitelist is deprecated, ' +
-                      'please use bridges config instead');
+      'please use bridges config instead');
   }
 
   if (options.bridgeUri) {
     this._logger.warn('config bridgeUri is deprecated, please ' +
-                      'use bridges config instead');
+      'use bridges config instead');
   }
 
   if (options.renterWhitelist && options.bridges) {
     this._logger.warn('config renterWhitelist and bridges are mutually ' +
-                      'exclusive, bridges config used only');
+      'exclusive, bridges config used only');
   }
 
   if (options.bridgeUri && options.bridges) {
     this._logger.warn('config bridgeUri and bridges are mutually exclusive, ' +
-                      'bridges config used only');
+      'bridges config used only');
   }
 }
 
-FarmerInterface.prototype.isBridgeConnected = function(contract) {
+FarmerInterface.prototype.isBridgeConnected = function (contract) {
   if (!this.bridges) {
     this._logger.debug('no bridges are connected');
     return false;
   }
   var isConnected = this.bridges.has(contract.get('renter_hd_key'));
   this._logger.debug('contract is associated with connected bridge: %s',
-                     isConnected);
+    isConnected);
   if (!isConnected) {
     return false;
   }
@@ -149,7 +149,7 @@ FarmerInterface.prototype.isBridgeConnected = function(contract) {
  */
 
 // eslint-disable-next-line max-statements
-FarmerInterface.Negotiator = function(contract, callback) {
+FarmerInterface.Negotiator = function (contract, callback) {
   /* eslint complexity: [2, 7] */
   var self = this;
   const dataSize = contract.get('data_size');
@@ -199,7 +199,7 @@ FarmerInterface.Negotiator = function(contract, callback) {
     }
 
     // NB: Only bid on contracts for data we don't have
-    this.storageManager.load(contract.get('data_hash'), function(err, item) {
+    this.storageManager.load(contract.get('data_hash'), function (err, item) {
       if (err) {
         self._logger.debug('no storage item available for this shard');
         return callback(true);
@@ -237,10 +237,10 @@ FarmerInterface.DEFAULTS = {
  * successfully establishing a connection to the network
  * @param {Function} callback - Called on successful join
  */
-FarmerInterface.prototype.join = function(callback) {
+FarmerInterface.prototype.join = function (callback) {
   var self = this;
 
-  Network.prototype.join.call(this, function(err) {
+  Network.prototype.join.call(this, function (err) {
     if (err) {
       return callback(err);
     }
@@ -252,7 +252,7 @@ FarmerInterface.prototype.join = function(callback) {
     );
 
     /* istanbul ignore next*/
-    self.transport.shardServer.on('shardUploaded', function(){
+    self.transport.shardServer.on('shardUploaded', function () {
       if (self._dataReceivedCount < Number.MAX_SAFE_INTEGER) {
         self._dataReceivedCount++;
       } else {
@@ -264,7 +264,7 @@ FarmerInterface.prototype.join = function(callback) {
   });
 };
 
-FarmerInterface.prototype._mapBridges = function(bridges) {
+FarmerInterface.prototype._mapBridges = function (bridges) {
   this.bridges = new Map();
   for (let i = 0; i < bridges.length; i++) {
     this.bridges.set(bridges[i].extendedKey, {
@@ -275,7 +275,7 @@ FarmerInterface.prototype._mapBridges = function(bridges) {
   }
 };
 
-FarmerInterface.prototype._connectBridges = function() {
+FarmerInterface.prototype._connectBridges = function () {
   if (this._connectBridgesRunning) {
     return;
   }
@@ -289,7 +289,7 @@ FarmerInterface.prototype._connectBridges = function() {
     this._connectBridge(bridge, (err) => {
       if (err) {
         this._logger.error('Unable to connect to bridge: %s, reason: %s',
-                           bridge.url, err.message);
+          bridge.url, err.message);
         return next();
       }
       this.bridges.get(bridge.extendedKey).connected = true;
@@ -312,7 +312,7 @@ FarmerInterface.prototype._connectBridges = function() {
  * update the contact details, otherwise it will add the contact to
  * and begin the benchmarking phase.
  */
-FarmerInterface.prototype.connectBridges = function() {
+FarmerInterface.prototype.connectBridges = function () {
   this._connectBridges();
   this._connectBridgesInterval = setInterval(
     this._connectBridges.bind(this),
@@ -323,7 +323,7 @@ FarmerInterface.prototype.connectBridges = function() {
 /**
  * Mark if there is space available for accepting offers
  */
-FarmerInterface.prototype.runSpaceCheck = function() {
+FarmerInterface.prototype.runSpaceCheck = function () {
   this._runSpaceCheck();
   this._spaceCheckInterval = setInterval(
     this._runSpaceCheck.bind(this),
@@ -331,14 +331,14 @@ FarmerInterface.prototype.runSpaceCheck = function() {
   );
 }
 
-FarmerInterface.prototype._runSpaceCheck = function() {
+FarmerInterface.prototype._runSpaceCheck = function () {
 
   this._logger.debug('running free space check');
 
   diskusage.check(this._options.storagePath, (err, info) => {
     if (err) {
       this._logger.warn('unable to check disk usage in interval, reason: %s',
-                        err.message);
+        err.message);
       return;
     }
     if (info.available <= FarmerInterface.FREE_SPACE_PADDING) {
@@ -353,7 +353,7 @@ FarmerInterface.prototype._runSpaceCheck = function() {
  * This will change the state of the farmer so that it will stop receiving
  * messages to store data.
  */
-FarmerInterface.prototype.noSpaceLeft = function(noSpace) {
+FarmerInterface.prototype.noSpaceLeft = function (noSpace) {
   if (this.spaceAvailable === !noSpace) {
     return;
   }
@@ -368,7 +368,7 @@ FarmerInterface.prototype.noSpaceLeft = function(noSpace) {
   }
 };
 
-FarmerInterface.prototype._connectBridge = function(bridge, callback) {
+FarmerInterface.prototype._connectBridge = function (bridge, callback) {
   let headers = {};
   let body = {};
   let path = '/contacts/' + this.contact.nodeID;
@@ -380,9 +380,9 @@ FarmerInterface.prototype._connectBridge = function(bridge, callback) {
     }
 
     if (contact.address !== this.contact.address ||
-        contact.port !== this.contact.port ||
-        contact.spaceAvailable !== this.spaceAvailable ||
-        contact.protocol !== this.contact.protocol) {
+      contact.port !== this.contact.port ||
+      contact.spaceAvailable !== this.spaceAvailable ||
+      contact.protocol !== this.contact.protocol) {
       this._updateBridgeContact(bridge, callback);
     } else {
       callback();
@@ -390,7 +390,7 @@ FarmerInterface.prototype._connectBridge = function(bridge, callback) {
   });
 }
 
-FarmerInterface.prototype._addBridgeContact = function(bridge, callback) {
+FarmerInterface.prototype._addBridgeContact = function (bridge, callback) {
   let target = null;
   let challenge = null;
   let nonce = null;
@@ -437,7 +437,7 @@ FarmerInterface.prototype._addBridgeContact = function(bridge, callback) {
   ], callback);
 }
 
-FarmerInterface.prototype._updateBridgeContact = function(bridge, callback) {
+FarmerInterface.prototype._updateBridgeContact = function (bridge, callback) {
   const headers = {};
   const body = {
     address: this.contact.address,
@@ -447,20 +447,20 @@ FarmerInterface.prototype._updateBridgeContact = function(bridge, callback) {
   };
 
   this.bridgeRequest(bridge.url,
-                     'PATCH',
-                     '/contacts/' + this.contact.nodeID,
-                     headers,
-                     body,
-                     callback)
+    'PATCH',
+    '/contacts/' + this.contact.nodeID,
+    headers,
+    body,
+    callback)
 }
 
-FarmerInterface.prototype._completeChallenge = function(challenge,
-                                                        target,
-                                                        callback) {
+FarmerInterface.prototype._completeChallenge = function (challenge,
+  target,
+  callback) {
   const powScript = path.resolve(__dirname, './pow.js');
   const args = [
     powScript,
-    JSON.stringify({challenge: challenge, target: target})
+    JSON.stringify({ challenge: challenge, target: target })
   ];
   const options = {
     timeout: 900000
@@ -480,11 +480,11 @@ FarmerInterface.prototype._completeChallenge = function(challenge,
 }
 
 /* eslint max-params:0 */
-FarmerInterface.prototype._getSigHash = function(bridgeUrl,
-                                                 method,
-                                                 path,
-                                                 timestamp,
-                                                 rawbody) {
+FarmerInterface.prototype._getSigHash = function (bridgeUrl,
+  method,
+  path,
+  timestamp,
+  rawbody) {
   const hasher = crypto.createHash('sha256');
   hasher.update(method);
   hasher.update(bridgeUrl + path);
@@ -495,12 +495,12 @@ FarmerInterface.prototype._getSigHash = function(bridgeUrl,
 
 /* eslint max-params:0 */
 // eslint-disable-next-line max-statements
-FarmerInterface.prototype.bridgeRequest = function(bridgeUrl,
-                                                   method,
-                                                   path,
-                                                   headers,
-                                                   body,
-                                                   callback) {
+FarmerInterface.prototype.bridgeRequest = function (bridgeUrl,
+  method,
+  path,
+  headers,
+  body,
+  callback) {
 
   const urlObj = url.parse(bridgeUrl);
   const timestamp = Date.now();
@@ -576,7 +576,7 @@ FarmerInterface.prototype.bridgeRequest = function(bridgeUrl,
  * @param {Contract} contract - The contract to include in offer
  * @param {Contact} renter - The renter who originally published the contract
  */
-FarmerInterface.prototype._sendOfferForContract = function(contract, contact) {
+FarmerInterface.prototype._sendOfferForContract = function (contract, contact) {
   var self = this;
   var message = new kad.Message({
     method: 'OFFER',
@@ -588,7 +588,7 @@ FarmerInterface.prototype._sendOfferForContract = function(contract, contact) {
 
   self._logger.debug('Sending offer for contract hash %s',
     contract.get('data_hash'));
-  self.transport.send(contact, message, function(err, response) {
+  self.transport.send(contact, message, function (err, response) {
     if (err) {
       return self._logger.warn(err.message);
     }
@@ -607,7 +607,7 @@ FarmerInterface.prototype._sendOfferForContract = function(contract, contact) {
  * Returns the payment address supplied or the derived one from keypair
  * @returns {String}
  */
-FarmerInterface.prototype.getPaymentAddress = function() {
+FarmerInterface.prototype.getPaymentAddress = function () {
   return this._options.paymentAddress || this.keyPair.getAddress();
 };
 
@@ -616,7 +616,7 @@ FarmerInterface.prototype.getPaymentAddress = function() {
  * @private
  * @param {Contract} contract
  */
-FarmerInterface.prototype._negotiateContract = function(contract, contact) {
+FarmerInterface.prototype._negotiateContract = function (contract, contact) {
   var self = this;
 
   contract.set('farmer_id', self.keyPair.getNodeID());
@@ -633,7 +633,7 @@ FarmerInterface.prototype._negotiateContract = function(contract, contact) {
   item.addContract({ nodeID: renterId }, contract);
   item.addMetaData({ nodeID: renterId }, {});
 
-  self.storageManager.save(item, function(err) {
+  self.storageManager.save(item, function (err) {
     if (err) {
       return self._logger.error(err.message);
     }
@@ -649,7 +649,7 @@ FarmerInterface.prototype._negotiateContract = function(contract, contact) {
  * @param {Contract} contract
  * @param {Function} callback
  */
-FarmerInterface.prototype._shouldSendOffer = function(contract, callback) {
+FarmerInterface.prototype._shouldSendOffer = function (contract, callback) {
   var self = this;
 
   if (!this.spaceAvailable) {
@@ -657,14 +657,14 @@ FarmerInterface.prototype._shouldSendOffer = function(contract, callback) {
     return callback(false);
   }
 
-  this._negotiator.call(this, contract, function(shouldNegotiate) {
+  this._negotiator.call(this, contract, function (shouldNegotiate) {
     /* eslint max-statements: [2, 16] */
     self._logger.debug('negotiator returned: %s', shouldNegotiate);
     self.storageManager._storage.size(
       contract.get('data_hash'),
-      function(err, usedSpace, contractDBSize) {
+      function (err, usedSpace, contractDBSize) {
         if (err) {
-          self._logger.error('Could not get usedSpace: %s',err.message);
+          self._logger.error('Could not get usedSpace: %s', err.message);
           return callback(false);
         }
 
@@ -692,7 +692,7 @@ FarmerInterface.prototype._shouldSendOffer = function(contract, callback) {
  * Handles an offer response from a renter
  * @private
  */
-FarmerInterface.prototype._handleOfferRes = function(res, contract, renter) {
+FarmerInterface.prototype._handleOfferRes = function (res, contract, renter) {
   var self = this;
   var final = null;
 
@@ -706,7 +706,7 @@ FarmerInterface.prototype._handleOfferRes = function(res, contract, renter) {
     return self._logger.warn('renter signature is invalid');
   }
 
-  self.storageManager.load(contract.get('data_hash'), function(err, item) {
+  self.storageManager.load(contract.get('data_hash'), function (err, item) {
     if (err) {
       item = new StorageItem({ hash: contract.get('data_hash') });
     }
@@ -723,7 +723,7 @@ FarmerInterface.prototype._handleOfferRes = function(res, contract, renter) {
  * @private
  * @param {Array} opcodes
  */
-FarmerInterface.prototype._listenForContracts = function(opcodes) {
+FarmerInterface.prototype._listenForContracts = function (opcodes) {
   this.subscribe(opcodes, this._handleContractPublication.bind(this));
 };
 
@@ -732,7 +732,7 @@ FarmerInterface.prototype._listenForContracts = function(opcodes) {
  * @private
  * @param {Object} contract - The raw contract object
  */
-FarmerInterface.prototype._handleContractPublication = function(contract) {
+FarmerInterface.prototype._handleContractPublication = function (contract) {
   var self = this;
   var contractObj;
   var contact = contract.contact;
@@ -749,7 +749,7 @@ FarmerInterface.prototype._handleContractPublication = function(contract) {
     return; // If the renter signature is invalid just drop it
   }
 
-  this._shouldSendOffer(contractObj, function(shouldSendOffer) {
+  this._shouldSendOffer(contractObj, function (shouldSendOffer) {
     if (!shouldSendOffer) {
       return self._logger.debug('not sending an offer for the contract');
     }
@@ -763,7 +763,7 @@ FarmerInterface.prototype._handleContractPublication = function(contract) {
  * @param {Object} params
  * @param {Protocol~handleConsignCallback} callback
  */
-FarmerInterface.prototype.handleAlloc = function(params, callback) {
+FarmerInterface.prototype.handleAlloc = function (params, callback) {
   var self = this;
   var token = utils.generateToken();
 
@@ -780,11 +780,11 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
   }
 
   self._logger.info('handling alloc request from %s hash %s size %s',
-                    params.contact.nodeID,
-                    contractObj.get('data_hash'),
-                    contractObj.get('data_size'));
+    params.contact.nodeID,
+    contractObj.get('data_hash'),
+    contractObj.get('data_size'));
 
-  this._shouldSendOffer(contractObj, function(shouldSendOffer) {
+  this._shouldSendOffer(contractObj, function (shouldSendOffer) {
     if (!shouldSendOffer) {
       // TODO give back a reason
       self._logger.debug('not sending an offer for the contract');
@@ -806,7 +806,7 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
     item.addContract({ nodeID: renterId }, contractObj);
     item.addMetaData({ nodeID: renterId }, {});
 
-    self.storageManager.save(item, function(err) {
+    self.storageManager.save(item, function (err) {
       if (err) {
         self._logger.error(err.message);
         return callback(new Error('Error saving contract'));
@@ -825,8 +825,8 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
       }
 
       self._logger.info('Sending alloc response hash %s size %s',
-                        contractObj.get('data_hash'),
-                        contractObj.get('data_size'));
+        contractObj.get('data_hash'),
+        contractObj.get('data_size'));
 
       callback(null, { token: token, contract: contractObj.toObject() });
 
@@ -835,47 +835,69 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
   });
 }
 
-/************************************************
- * Cleaner
- ************************************************/
- FarmerInterface.prototype.initCleaner = function(greaterThan, endShardStream, callback) {
+/**
+ * 
+ * Function to initialize cleaner
+ * 
+ * @param {*} greaterThan     Last hash consulted to know where we finish (the first time is undefined so we start at the beginning)
+ * @param {*} endShardStream  Last hash in datashard database to know when to end 
+ * @param {*} callback        Function to execute when the process is finish or when we get an error
+ */
+FarmerInterface.prototype.initCleaner = function (greaterThan, endShardStream, callback) {
   const self = this;
 
-  /** We make 500 shards batch **/
+  /** Object: We make 500 shards batch(Limit) **/
   const streamOptions = {
-    limit: 2,
+    limit: 1000,
     gt: greaterThan
-  } 
-
-  if(!endShardStream)
-  {
-    endShardStream = self.storageManager.getLastShard();
   }
 
-  self.storageManager.readShards(streamOptions, (err, arr, lastShard) => {
+  /** If we have the last shard on the sharddata.db we do not have to consult it */
+  if (!endShardStream) {
+    self.storageManager.getLastShard(streamOptions, self.performClean.bind(this), callback);
+  }
+  else {
+    self.performClean(streamOptions, endShardStream, callback);
+  }
+}
+
+FarmerInterface.prototype.performClean = function (streamOptions, endShardStream, callback) {
+  const self = this;
+
+  self.storageManager.readShards(streamOptions, (err, coreShards, lastShard) => {
     if (err) {
       return callback(err);
     }
-    
-    this.getShardsFromBridge(arr, (err, bridgeShards) => {
-      if(err) {
-        callback(err);
-      }
-      self._logger.info('Core Shards', arr);
-      self._logger.info('Bridge Shards', bridgeShards);
-      self.storageManager.cleaner(bridgeShards, streamOptions, (err) => {
-        if(err) {
-          callback(err)
+
+    console.log('Last Shard: ', lastShard)
+    console.log('End Stream Shard: ', endShardStream)
+
+    if (coreShards.length > 0) {
+      this.getShardsFromBridge(coreShards, (err, bridgeShards) => {
+        if (err) {
+          callback(err);
         }
-        
-        /**
-         * We repeat the process until with finish with all the shards
-         */
-        if(lastShard !== endShardStream) {
-          this.initCleaner(lastShard, endShardStream, callback);
-        } 
+        self._logger.info('Core Shards', coreShards);
+        self._logger.info('Bridge Shards', bridgeShards);
+        self.storageManager.cleaner(coreShards, bridgeShards, streamOptions, (err) => {
+          if (err) {
+            callback(err)
+          }
+
+          /**
+           * We repeat the process until with finish with all the shards
+           */
+          if (lastShard !== endShardStream) {
+            this.initCleaner(lastShard, endShardStream, callback);
+          }
+        });
       });
-    });
+    }
+    else {
+      if (lastShard !== endShardStream) {
+        this.initCleaner(lastShard, endShardStream, callback);
+      }
+    }
   });
 }
 
@@ -886,10 +908,10 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
  * @param {Array} shards 
  * @param {Function} callback 
  */
-FarmerInterface.prototype.getShardsFromBridge = function(shards, callback) {
+FarmerInterface.prototype.getShardsFromBridge = function (shards, callback) {
   const bridgeIter = this.bridges.values()
   this._getShardsFromBridge(bridgeIter.next().value, shards, (err, shardsRetrieved) => {
-    if(err) {
+    if (err) {
       callback(err);
     }
     else {
@@ -898,11 +920,11 @@ FarmerInterface.prototype.getShardsFromBridge = function(shards, callback) {
   })
 }
 
-FarmerInterface.prototype._getShardsFromBridge = function(bridge, shards, callback) {
+FarmerInterface.prototype._getShardsFromBridge = function (bridge, shards, callback) {
   let headers = {};
-  let body = {shards};
+  let body = { shards };
   let path = '/contacts/shards';
-  
+
   this.bridgeRequest(bridge.url, 'POST', path, headers, body, callback);
 }
 

--- a/lib/storage/adapter.js
+++ b/lib/storage/adapter.js
@@ -166,8 +166,8 @@ StorageAdapter.prototype.flush = function(callback) {
  * stream containing each stored item
  * @return {ReadableStream}
  */
-StorageAdapter.prototype.createReadStream = function() {
-  return this._keys().pipe(new stream.Transform({
+StorageAdapter.prototype.createReadStream = function(options) {
+  return this._keys(options).pipe(new stream.Transform({
     objectMode: true,
     transform: (key, enc, next) => {
       this.peek(key.toString(), next);

--- a/lib/storage/adapters/embedded.js
+++ b/lib/storage/adapters/embedded.js
@@ -57,6 +57,8 @@ EmbeddedStorageAdapter.prototype._validatePath = function(storageDirPath) {
  * @param {Function} callback
  */
 EmbeddedStorageAdapter.prototype._get = function(key, callback) {
+  console.log('AVOID ALLOC')
+  return callback(Error('NO SPACE'));
   var self = this;
 
   this._db.get(key, { fillCache: false }, function(err, value) {
@@ -279,5 +281,21 @@ EmbeddedStorageAdapter.prototype._close = function(callback) {
 
   callback(null);
 };
+
+/**
+ * Look up if the data exists on datashardDB
+ * 
+ * @param {*} fskey File Key on contracts database 
+ */
+EmbeddedStorageAdapter.prototype.existDataShard = function(fsKey, callback) {
+  const self = this;
+
+  self._fs.exists(fsKey, function(err, exists) {
+    if (err) {
+      return callback(err);
+    }
+    callback(null, exists)
+  });
+}
 
 module.exports = EmbeddedStorageAdapter;

--- a/lib/storage/adapters/embedded.js
+++ b/lib/storage/adapters/embedded.js
@@ -232,8 +232,8 @@ EmbeddedStorageAdapter.prototype._size = function(key, callback) {
  * @private
  * @returns {ReadableStream}
  */
-EmbeddedStorageAdapter.prototype._keys = function() {
-  return this._db.createKeyStream();
+EmbeddedStorageAdapter.prototype._keys = function(options) {
+  return this._db.createKeyStream(options);
 };
 
 /**

--- a/lib/storage/adapters/embedded.js
+++ b/lib/storage/adapters/embedded.js
@@ -57,8 +57,6 @@ EmbeddedStorageAdapter.prototype._validatePath = function(storageDirPath) {
  * @param {Function} callback
  */
 EmbeddedStorageAdapter.prototype._get = function(key, callback) {
-  console.log('AVOID ALLOC')
-  return callback(Error('NO SPACE'));
   var self = this;
 
   this._db.get(key, { fillCache: false }, function(err, value) {

--- a/lib/storage/adapters/embedded.js
+++ b/lib/storage/adapters/embedded.js
@@ -280,4 +280,28 @@ EmbeddedStorageAdapter.prototype._close = function(callback) {
   callback(null);
 };
 
+/****************************************************************
+ * 
+ * Cleaner
+ * 
+ ****************************************************************/
+ EmbeddedStorageAdapter.prototype.readAllContracts = function(callback) {
+  let arr = [];
+
+  let stream = this._db.createReadStream();
+
+  stream.on('data', function (data) {
+    const key = data.key.toString();
+    arr.push(key);
+  });
+  
+  stream.on('error', function (err) {
+    callback(err)
+  });
+
+  stream.on('end', function () {
+    callback(null, arr)
+  });
+}
+
 module.exports = EmbeddedStorageAdapter;

--- a/lib/storage/adapters/embedded.js
+++ b/lib/storage/adapters/embedded.js
@@ -280,28 +280,4 @@ EmbeddedStorageAdapter.prototype._close = function(callback) {
   callback(null);
 };
 
-/****************************************************************
- * 
- * Cleaner
- * 
- ****************************************************************/
- EmbeddedStorageAdapter.prototype.readAllContracts = function(callback) {
-  let arr = [];
-
-  let stream = this._db.createReadStream();
-
-  stream.on('data', function (data) {
-    const key = data.key.toString();
-    arr.push(key);
-  });
-  
-  stream.on('error', function (err) {
-    callback(err)
-  });
-
-  stream.on('end', function () {
-    callback(null, arr)
-  });
-}
-
 module.exports = EmbeddedStorageAdapter;

--- a/lib/storage/manager.js
+++ b/lib/storage/manager.js
@@ -191,4 +191,45 @@ StorageManager.prototype._initShardReaper = function() {
              constants.CLEAN_INTERVAL);
 };
 
+/*************************************************
+ * Cleaner
+ *************************************************/
+ StorageManager.prototype.cleaner = function(bridgeShards, callback) {
+  const self = this;
+  const rstream = this._storage.createReadStream();
+
+  this._logger.info('starting cleaner');
+
+  rstream.on('data', function(item) {
+    rstream.pause();
+    
+    if (!bridgeShards.includes(item.hash)) {
+      self._logger.info('destroying shard/contract for %s', item.hash);
+      self._storage.del(item.hash, function(/* err */) {
+        rstream.resume();
+      });
+    } else {
+      rstream.resume();
+    }
+  });
+
+  rstream.on('end', function() {
+    self._logger.info('flushing shards, some buckets will be inaccessible');
+    self._storage.flush(function(err) {
+      /* istanbul ignore if */
+      if (err) {
+        self._logger.warn('problem while flushing shards, %s', err.message);
+      }
+
+      self._logger.info('flushing shards finished');
+      callback();
+    });
+  });
+};
+
+StorageManager.prototype.readAllContracts = function(callback) { 
+  const self = this;
+  self._storage.readAllContracts(callback)
+};
+
 module.exports = StorageManager;

--- a/lib/storage/manager.js
+++ b/lib/storage/manager.js
@@ -8,6 +8,7 @@ var merge = require('merge');
 var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
 var Logger = require('kad-logger-json');
+const { Console } = require('console');
 
 /**
  * Interface for managing contracts, shards, and audits
@@ -47,12 +48,12 @@ StorageManager.DEFAULTS = {
  * @param {String} hash - Shard hash to load data for
  * @param {Function} callback - Called with error or {@link StorageItem}
  */
-StorageManager.prototype.load = function(hash, callback) {
+StorageManager.prototype.load = function (hash, callback) {
   assert(typeof hash === 'string', 'Invalid key supplied');
   assert(hash.length === 40, 'Key must be 160 bit hex string');
   assert(typeof callback === 'function', 'Callback function must be supplied');
 
-  this._storage.get(hash, function(err, item) {
+  this._storage.get(hash, function (err, item) {
     if (err) {
       return callback(err);
     }
@@ -70,16 +71,16 @@ StorageManager.prototype.load = function(hash, callback) {
  * @param {StorageItem} item - The {@link StorageItem} to store
  * @param {Function} callback - Called on complete
  */
-StorageManager.prototype.save = function(item, callback) {
+StorageManager.prototype.save = function (item, callback) {
   var self = this;
 
   assert(item instanceof StorageItem, 'Invalid storage item supplied');
   assert(typeof callback === 'function', 'Callback function must be supplied');
 
-  self._storage.get(item.hash, function(err, existingItem) {
+  self._storage.get(item.hash, function (err, existingItem) {
     self._storage.put(
       self._merge(existingItem, item),
-      function(err) {
+      function (err) {
         if (err) {
           return callback(err);
         }
@@ -94,7 +95,7 @@ StorageManager.prototype.save = function(item, callback) {
  * Merges two storage items together
  * @private
  */
-StorageManager.prototype._merge = function(item1, item2) {
+StorageManager.prototype._merge = function (item1, item2) {
   return new StorageItem(
     merge.recursive(
       true,
@@ -116,7 +117,7 @@ StorageManager.prototype._merge = function(item1, item2) {
  * Opens the underlying storage adapter
  * @param {Function} callback - Called on complete
  */
-StorageManager.prototype.open = function(callback) {
+StorageManager.prototype.open = function (callback) {
   this._storage._open(callback);
 };
 
@@ -124,7 +125,7 @@ StorageManager.prototype.open = function(callback) {
  * Closes the underlying storage adapter
  * @param {Function} callback - Called on complete
  */
-StorageManager.prototype.close = function(callback) {
+StorageManager.prototype.close = function (callback) {
   this._storage._close(callback);
 };
 
@@ -132,14 +133,14 @@ StorageManager.prototype.close = function(callback) {
  * Enumerates all storage contracts and reaps stale data
  * @param {Function} callback - Called on complete
  */
-StorageManager.prototype.clean = function(callback) {
+StorageManager.prototype.clean = function (callback) {
   var self = this;
   var rstream = this._storage.createReadStream();
   var timestamp = Date.now();
 
   this._logger.info('starting shard reaper, checking for expired contracts');
 
-  rstream.on('data', function(item) {
+  rstream.on('data', function (item) {
     rstream.pause();
 
     var total = Object.keys(item.contracts).length;
@@ -156,7 +157,7 @@ StorageManager.prototype.clean = function(callback) {
 
     if (total === endedOrIncomplete) {
       self._logger.info('destroying shard/contract for %s', item.hash);
-      self._storage.del(item.hash, function(/* err */) {
+      self._storage.del(item.hash, function (/* err */) {
         rstream.resume();
       });
     } else {
@@ -164,9 +165,9 @@ StorageManager.prototype.clean = function(callback) {
     }
   });
 
-  rstream.on('end', function() {
+  rstream.on('end', function () {
     self._logger.info('flushing shards, some buckets will be inaccessible');
-    self._storage.flush(function(err) {
+    self._storage.flush(function (err) {
       /* istanbul ignore if */
       if (err) {
         self._logger.warn('problem while flushing shards, %s', err.message);
@@ -182,33 +183,37 @@ StorageManager.prototype.clean = function(callback) {
  * Initialize the shard reaper to check for stale contracts and reap shards
  * @private
  */
-StorageManager.prototype._initShardReaper = function() {
+StorageManager.prototype._initShardReaper = function () {
   if (this._options.disableReaper) {
     return false;
   }
 
   setTimeout(this.clean.bind(this, this._initShardReaper.bind(this)),
-             constants.CLEAN_INTERVAL);
+    constants.CLEAN_INTERVAL);
 };
 
 /*************************************************
  * Cleaner
  *************************************************/
- StorageManager.prototype.cleaner = function(bridgeShards, streamOptions, callback) {
+StorageManager.prototype.cleaner = function (coreShards, bridgeShards, streamOptions, callback) {
   const self = this;
   const rstream = this._storage.createReadStream(streamOptions);
-
-  this._logger.info('starting cleaner');
-
-  rstream.on('data', function(item) {
+  
+  rstream.on('data', function (item) {
     rstream.pause();
-    
-    if (!bridgeShards.includes(item.hash)) {
-      self._logger.info('destroying shard/contract for %s', item.hash);
-      self._storage.del(item.hash, function(/* err */) {
+
+    if (coreShards.includes(item.hash)) {
+      if (!bridgeShards.includes(item.hash)) {
+        self._logger.info('destroying shard/contract for %s', item.hash);
+        self._storage.del(item.hash, function (/* err */) {
+          rstream.resume();
+        });
+      }
+      else {
         rstream.resume();
-      });
-    } else {
+      }
+    }
+    else {
       rstream.resume();
     }
   });
@@ -217,9 +222,9 @@ StorageManager.prototype._initShardReaper = function() {
     callback(err);
   });
 
-  rstream.on('end', function() {
+  rstream.on('end', function () {
     self._logger.info('flushing shards, some buckets will be inaccessible');
-    self._storage.flush(function(err) {
+    self._storage.flush(function (err) {
       /* istanbul ignore if */
       if (err) {
         self._logger.warn('problem while flushing shards, %s', err.message);
@@ -236,14 +241,25 @@ StorageManager.prototype._initShardReaper = function() {
  * @param {*} options 
  * @param {*} callback 
  */
-StorageManager.prototype.readShards = function(options, callback) { 
+StorageManager.prototype.readShards = function (options, callback) {
   const self = this;
   const rstream = this._storage.createReadStream(options);
   let arr = [];
-  
-  rstream.on('data', function(item) {
+  let lastItem = null;
+
+  rstream.on('data', function (item) {
     rstream.pause();
-    arr.push(item.hash);
+
+    let fskey = item.fskey;
+    self._storage.existDataShard(fskey, (err, exists) => {
+      if (err) {
+        self._logger.warn('Error on looking for shard on DataShardDB');
+      }
+      if (exists) {
+        arr.push(item.hash);
+      }
+      lastItem = item.hash;
+    })
     rstream.resume();
   });
 
@@ -251,11 +267,11 @@ StorageManager.prototype.readShards = function(options, callback) {
     callback(err);
   });
 
-  rstream.on('end', function() {
+  rstream.on('end', function () {
     self._logger.info('Finish reading all Shards');
-    callback(null, arr, arr[arr.length-1]);
+    callback(null, arr,  lastItem);
   });
-  
+
 };
 
 
@@ -264,7 +280,7 @@ StorageManager.prototype.readShards = function(options, callback) {
  * Get hash of the last shard of LevelDB
  * 
  */
-StorageManager.prototype.getLastShard = function() { 
+StorageManager.prototype.getLastShard = function (streamOption, func1, callback) {
   const self = this;
   const options = {
     reverse: true,
@@ -272,8 +288,8 @@ StorageManager.prototype.getLastShard = function() {
   }
   const rstream = this._storage.createReadStream(options);
   let lastShardDB = '';
-  
-  rstream.on('data', function(item) {
+
+  rstream.on('data', function (item) {
     rstream.pause();
     lastShardDB = item.hash;
     rstream.resume();
@@ -283,11 +299,12 @@ StorageManager.prototype.getLastShard = function() {
     callback(err);
   });
 
-  rstream.on('end', function() {
+  rstream.on('end', function () {
     self._logger.info('Retrieve Last Shard');
+    func1(streamOption, lastShardDB, callback);
     return lastShardDB;
   });
-  
+
 };
 
 

--- a/lib/storage/manager.js
+++ b/lib/storage/manager.js
@@ -194,7 +194,7 @@ StorageManager.prototype._initShardReaper = function() {
 /*************************************************
  * Cleaner
  *************************************************/
- StorageManager.prototype.cleaner = function(bridgeShards, callback) {
+StorageManager.prototype.cleaner = function(bridgeShards, callback) {
   const self = this;
   const rstream = this._storage.createReadStream();
 
@@ -227,9 +227,28 @@ StorageManager.prototype._initShardReaper = function() {
   });
 };
 
+
 StorageManager.prototype.readAllContracts = function(callback) { 
   const self = this;
-  self._storage.readAllContracts(callback)
+  const rstream = this._storage.createReadStream();
+  let arr = [];
+  
+  rstream.on('data', function(item) {
+    rstream.pause();
+    console.log(item);
+    arr.push(item.hash);
+    rstream.resume();
+  });
+
+  rstream.on('error', function (err) {
+    callback(err);
+  });
+
+  rstream.on('end', function() {
+    self._logger.info('Finish reading all Shards');
+    callback(null, arr);
+  });
+  
 };
 
 module.exports = StorageManager;

--- a/lib/storage/manager.js
+++ b/lib/storage/manager.js
@@ -194,9 +194,9 @@ StorageManager.prototype._initShardReaper = function() {
 /*************************************************
  * Cleaner
  *************************************************/
-StorageManager.prototype.cleaner = function(bridgeShards, callback) {
+ StorageManager.prototype.cleaner = function(bridgeShards, streamOptions, callback) {
   const self = this;
-  const rstream = this._storage.createReadStream();
+  const rstream = this._storage.createReadStream(streamOptions);
 
   this._logger.info('starting cleaner');
 
@@ -213,6 +213,10 @@ StorageManager.prototype.cleaner = function(bridgeShards, callback) {
     }
   });
 
+  rstream.on('error', function (err) {
+    callback(err);
+  });
+
   rstream.on('end', function() {
     self._logger.info('flushing shards, some buckets will be inaccessible');
     self._storage.flush(function(err) {
@@ -227,15 +231,18 @@ StorageManager.prototype.cleaner = function(bridgeShards, callback) {
   });
 };
 
-
-StorageManager.prototype.readAllContracts = function(callback) { 
+/**
+ * 
+ * @param {*} options 
+ * @param {*} callback 
+ */
+StorageManager.prototype.readShards = function(options, callback) { 
   const self = this;
-  const rstream = this._storage.createReadStream();
+  const rstream = this._storage.createReadStream(options);
   let arr = [];
   
   rstream.on('data', function(item) {
     rstream.pause();
-    console.log(item);
     arr.push(item.hash);
     rstream.resume();
   });
@@ -246,9 +253,43 @@ StorageManager.prototype.readAllContracts = function(callback) {
 
   rstream.on('end', function() {
     self._logger.info('Finish reading all Shards');
-    callback(null, arr);
+    callback(null, arr, arr[arr.length-1]);
   });
   
 };
 
+
+/**
+ * 
+ * Get hash of the last shard of LevelDB
+ * 
+ */
+StorageManager.prototype.getLastShard = function() { 
+  const self = this;
+  const options = {
+    reverse: true,
+    limit: 1,
+  }
+  const rstream = this._storage.createReadStream(options);
+  let lastShardDB = '';
+  
+  rstream.on('data', function(item) {
+    rstream.pause();
+    lastShardDB = item.hash;
+    rstream.resume();
+  });
+
+  rstream.on('error', function (err) {
+    callback(err);
+  });
+
+  rstream.on('end', function() {
+    self._logger.info('Retrieve Last Shard');
+    return lastShardDB;
+  });
+  
+};
+
+
 module.exports = StorageManager;
+


### PR DESCRIPTION
Added cleaner functionality to core.

Now we open the database (Contracts) to get the shards. In batches of two to test but this can be change once we tested it to be batches of 500 items.

Then we send these hashes to bridge.

Bridge responds with and array of the hash that are in mongoDB.

Once again we open up the contract database (with the same options as before) and we check if the hash is in the array that bridge gave us, if not we erase that shards.

Finally we flush the database